### PR TITLE
feat: add creatives tables and sectors page

### DIFF
--- a/src/app/features/repositories/catalog/creative.repository.ts
+++ b/src/app/features/repositories/catalog/creative.repository.ts
@@ -1,0 +1,20 @@
+import { CreativeRepository } from "src/domain/creatives/creatives.domain";
+import {
+  CreativeLibraryFilter,
+  CreativeLibraryFolder,
+} from "src/graphql/client";
+import { client } from "../clients/graphql.client";
+
+export class CreativeBackendRepository implements CreativeRepository {
+  async getCreativeLibraryFolder(input: CreativeLibraryFilter) {
+    return client.chain.query.listFolder({ input }).get({
+      creatives: {
+        creativeId: 1,
+        name: 1,
+        fileType: 1,
+        url: 1,
+        createdAt: 1,
+      },
+    }) as Promise<CreativeLibraryFolder>;
+  }
+}

--- a/src/app/features/repositories/catalog/index.ts
+++ b/src/app/features/repositories/catalog/index.ts
@@ -1,13 +1,15 @@
-import { BrandBackendRepository } from "./brand.repository";
-import { UsersBackendRepository } from "./users.repository";
 import { AssetsBackendRepository } from "./assets.repository";
+import { BrandBackendRepository } from "./brand.repository";
 import { BusinessBackendRepository } from "./business.repository";
+import { CreativeBackendRepository } from "./creative.repository";
 import { EarlyAccessBackendRepository } from "./early-access.repository";
+import { UsersBackendRepository } from "./users.repository";
 
 export const repository = new Map();
 
-repository.set("BrandRepository", BrandBackendRepository);
-repository.set("UsersRepository", UsersBackendRepository);
 repository.set("AssetsRepository", AssetsBackendRepository);
-repository.set("EarlyAccessRepository", EarlyAccessBackendRepository);
+repository.set("BrandRepository", BrandBackendRepository);
 repository.set("BusinessRepository", BusinessBackendRepository);
+repository.set("CreativeRepository", CreativeBackendRepository);
+repository.set("EarlyAccessRepository", EarlyAccessBackendRepository);
+repository.set("UsersRepository", UsersBackendRepository);

--- a/src/app/features/repositories/catalog/users.repository.ts
+++ b/src/app/features/repositories/catalog/users.repository.ts
@@ -11,12 +11,13 @@ export class UsersBackendRepository implements UsersRepository {
       businessAccount: {
         id: true,
         brands: {
-          id: true,
-          name: true,
-          logoUrl: true,
-          status: true,
           adAccounts: true,
+          id: true,
+          logoUrl: true,
+          name: true,
+          sector: true,
           socialAccounts: true,
+          status: true,
         },
       },
       isAdmin: true,

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/creative-lab.routes.ts
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/creative-lab.routes.ts
@@ -8,10 +8,22 @@ const CreativeLibraryPage = lazy(
     ),
 );
 
+const SectorsPage = lazy(
+  () =>
+    import(
+      "src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/sectors/sectors.page"
+    ),
+);
+
 export const CreativeLabRoutes: Route[] = [
   {
     path: "/library",
     element: CreativeLibraryPage,
     title: "Library",
+  },
+  {
+    path: "/sectors",
+    element: SectorsPage,
+    title: "Sectors",
   },
 ];

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
@@ -1,8 +1,24 @@
 import { FC } from "react";
+import { useSessionFeature } from "src/app/features/session/session.feature";
 import CardPageUI from "src/app/ui/cards/card-page.ui";
+import { EmptyCreateUI } from "src/app/ui/empty/empty-create.ui";
 import { SearchInputUI } from "src/app/ui/inputs/search-input.ui";
+import { useCreativesDomain } from "src/domain/creatives/creatives.domain";
+import useSWR from "swr";
+import { CreativesTableWidget } from "./creative.table.widget";
 
 const CreativeLibraryPage: FC = () => {
+  const { currentBrand } = useSessionFeature();
+  const { getCreativeLibraryFolder } = useCreativesDomain();
+
+  const { data: creativeLibraryFolder } = useSWR(
+    ["gettingCreativeLibraryFolder", currentBrand?.id],
+    ([url, brandId]) =>
+      getCreativeLibraryFolder(brandId ? { brandId } : { brandId: "" }),
+  );
+
+  const creatives = creativeLibraryFolder?.creatives ?? [];
+
   return (
     <CardPageUI>
       <header
@@ -17,7 +33,11 @@ const CreativeLibraryPage: FC = () => {
       >
         <SearchInputUI />
       </header>
-      <pre>Insert Table here</pre>
+      {creatives?.length > 0 ? (
+        <CreativesTableWidget data={creatives} />
+      ) : (
+        <EmptyCreateUI description="You don't have any creatives yet." />
+      )}
     </CardPageUI>
   );
 };

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative.table.widget.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative.table.widget.tsx
@@ -1,0 +1,68 @@
+import { Avatar } from "antd";
+import { ColumnsType } from "antd/es/table";
+import { FC } from "react";
+import { TableUI } from "src/app/ui/tables/table.ui";
+import { CreativeLibraryItem } from "src/graphql/client";
+
+interface CreativesTableWidgetProps {
+  data: CreativeLibraryItem[];
+}
+
+export const CreativesTableWidget: FC<CreativesTableWidgetProps> = ({
+  data = [],
+}) => {
+  const generateCreativeKey = (creative: CreativeLibraryItem) => ({
+    ...creative,
+    key: creative.creativeId,
+  });
+
+  const columns: ColumnsType<CreativeLibraryItem> = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      render: (name, record) => {
+        return (
+          <div style={{ display: "flex", gap: "8px" }}>
+            <Avatar
+              src={record.url}
+              style={{
+                backgroundColor: "rgb(230 244 255)",
+                color: "#1677ff",
+                fontWeight: "bold",
+              }}
+            >
+              {record.url ? "" : name}
+            </Avatar>
+            <div className="flex items-center">
+              <div>{name}</div>
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      title: "File Type",
+      dataIndex: "fileType",
+      render: (name, record) => {
+        return (
+          <div className="flex items-center">
+            <div>{record.fileType}</div>
+          </div>
+        );
+      },
+    },
+    {
+      title: "Creation Date",
+      dataIndex: "createdAt",
+      render: (name, record) => {
+        return (
+          <div className="flex items-center">
+            <div>{record.createdAt}</div>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return <TableUI columns={columns} data={data.map(generateCreativeKey)} />;
+};

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/sectors/sectors.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/sectors/sectors.page.tsx
@@ -1,0 +1,26 @@
+import { FC } from "react";
+import CardPageUI from "src/app/ui/cards/card-page.ui";
+import { EmptyCreateUI } from "src/app/ui/empty/empty-create.ui";
+import { SearchInputUI } from "src/app/ui/inputs/search-input.ui";
+import { useSectorsDomain } from "src/domain/sectors/sectors.domain";
+import { SectorsTableWidget } from "./sectors.table.widget";
+import { useSessionFeature } from "src/app/features/session/session.feature";
+
+const SectorsPage: FC = () => {
+  const { currentBrand } = useSessionFeature();
+  const { sectors } = useSectorsDomain();
+
+  return (
+    <CardPageUI>
+      {sectors?.length > 0 ? (
+        <SectorsTableWidget
+          data={sectors}
+          currentBrandSectors={currentBrand?.sector}
+        />
+      ) : (
+        <EmptyCreateUI description="You don't have any sectors yet." />
+      )}
+    </CardPageUI>
+  );
+};
+export default SectorsPage;

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/sectors/sectors.table.widget.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/sectors/sectors.table.widget.tsx
@@ -1,0 +1,54 @@
+import { ColumnsType } from "antd/es/table";
+import { FC } from "react";
+import { TableUI } from "src/app/ui/tables/table.ui";
+import { useSectorsDomain } from "src/domain/sectors/sectors.domain";
+import { Sector, SectorItem } from "src/graphql/client";
+
+interface SectorsTableWidgetProps {
+  currentBrandSectors?: Sector[];
+  data?: SectorItem[];
+}
+
+export const SectorsTableWidget: FC<SectorsTableWidgetProps> = ({
+  currentBrandSectors = [],
+  data = [],
+}) => {
+  const { isSectorOnBrand } = useSectorsDomain();
+  const generateSectorKey = (sector: SectorItem) => ({
+    ...sector,
+    key: sector.id,
+  });
+
+  const columns: ColumnsType<SectorItem> = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      render: (name, record) => {
+        return (
+          <div className="flex items-center">
+            <div>{record.name}</div>
+          </div>
+        );
+      },
+    },
+    {
+      title: "Is applied to current brand",
+      dataIndex: "fileType",
+      render: (name, record) => {
+        return (
+          <div className="flex items-center">
+            <div>
+              {isSectorOnBrand(record, currentBrandSectors) ? (
+                <span role="img" aria-label="sheep">
+                  ✅
+                </span>
+              ) : null}
+            </div>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return <TableUI columns={columns} data={data.map(generateSectorKey)} />;
+};

--- a/src/domain/creatives/creatives.domain.ts
+++ b/src/domain/creatives/creatives.domain.ts
@@ -1,0 +1,22 @@
+import { useRepositoryFeature } from "src/app/features/repositories/repositories.feature";
+import {
+  CreativeLibraryFilter,
+  CreativeLibraryFolder,
+} from "src/graphql/client";
+
+export interface CreativeRepository {
+  getCreativeLibraryFolder(
+    input: CreativeLibraryFilter,
+  ): Promise<CreativeLibraryFolder>;
+}
+
+export const useCreativesDomain = (repoId = "CreativeRepository") => {
+  const { repository } = useRepositoryFeature<CreativeRepository>(repoId);
+
+  const getCreativeLibraryFolder = (input: CreativeLibraryFilter) =>
+    repository.getCreativeLibraryFolder(input);
+
+  return {
+    getCreativeLibraryFolder,
+  };
+};

--- a/src/domain/sectors/sectors.domain.ts
+++ b/src/domain/sectors/sectors.domain.ts
@@ -1,0 +1,62 @@
+import { Sector, SectorItem } from "src/graphql/client";
+
+const sectors: SectorItem[] = [
+  { id: 0, name: "ApparelAndAccessories" },
+  { id: 1, name: "BeautyAndPersonalCare" },
+  { id: 2, name: "FoodAndBeverage" },
+  { id: 3, name: "HomeAndGarden" },
+  { id: 4, name: "SportsAndFitness" },
+  { id: 5, name: "HomeAppliances" },
+  { id: 6, name: "HomeImprovement" },
+  { id: 7, name: "HouseholdSupplies" },
+  { id: 8, name: "PetCare" },
+  { id: 9, name: "TobaccoAndSmokingAccessories" },
+  { id: 10, name: "ToysAndGames" },
+  { id: 11, name: "OilAndGas" },
+  { id: 12, name: "RenewableEnergy" },
+  { id: 13, name: "Utilities" },
+  { id: 14, name: "BankingAndLending" },
+  { id: 15, name: "Insurance" },
+  { id: 16, name: "InvestmentAndWealthManagement" },
+  { id: 17, name: "PharmaceuticalsAndBiotechnology" },
+  { id: 18, name: "MedicalDevices" },
+  { id: 19, name: "HealthcareServices" },
+  { id: 20, name: "ConstructionAndEngineering" },
+  { id: 21, name: "AerospaceAndDefense" },
+  { id: 22, name: "TransportationEquipment" },
+  { id: 23, name: "SoftwareAndITServices" },
+  { id: 24, name: "HardwareAndElectronics" },
+  { id: 25, name: "InternetServices" },
+  { id: 26, name: "TelecommunicationsEquipment" },
+  { id: 27, name: "TelecommunicationsServices" },
+  { id: 28, name: "NetworkingEquipment" },
+  { id: 29, name: "AirlinesAndAirTransportation" },
+  { id: 30, name: "HotelsAndResorts" },
+  { id: 31, name: "RestaurantsAndFoodServices" },
+  { id: 32, name: "TravelAgenciesAndTourOperators" },
+  { id: 33, name: "AmusementParksAndAttractions" },
+  { id: 34, name: "TelevisionBroadcastingAndProduction" },
+  { id: 35, name: "FilmProductionAndDistribution" },
+  { id: 36, name: "MusicRecordingAndProduction" },
+  { id: 37, name: "Publishing" },
+  { id: 38, name: "Gaming" },
+  { id: 39, name: "ResidentialRealEstate" },
+  { id: 40, name: "CommercialRealEstate" },
+  { id: 41, name: "RealEstateInvestmentTrusts" },
+  { id: 42, name: "RealEstateDevelopmentAndConstruction" },
+  { id: 43, name: "PublicAndPrivateSchools" },
+  { id: 44, name: "CollegesAndUniversities" },
+  { id: 45, name: "OnlineEducationPlatforms" },
+  { id: 46, name: "VocationalAndTechnicalSchools" },
+  { id: 47, name: "CorporateTrainingAndDevelopment" },
+];
+
+export const useSectorsDomain = () => {
+  const isSectorOnBrand = (sector: SectorItem, brandSectors: Sector[]) =>
+    brandSectors.includes(sector.name);
+
+  return {
+    sectors,
+    isSectorOnBrand,
+  };
+};

--- a/src/graphql/client/schema.ts
+++ b/src/graphql/client/schema.ts
@@ -596,6 +596,11 @@ export type Sector =
   | "VocationalAndTechnicalSchools"
   | "CorporateTrainingAndDevelopment";
 
+export interface SectorItem {
+  id: number;
+  name: Sector;
+}
+
 /** Brand Status */
 export type BrandStatus =
   | "IN_PROGRESS"
@@ -5100,9 +5105,7 @@ export interface BrandObservableChain {
 
 export interface MutationPromiseChain {
   /** Creates a business Account for the provided business admin */
-  createBrand: (args: {
-    input: CreateBrandInput;
-  }) => BrandPromiseChain & {
+  createBrand: (args: { input: CreateBrandInput }) => BrandPromiseChain & {
     get: <R extends BrandRequest>(
       request: R,
       defaultValue?: FieldsSelection<Brand, R>,
@@ -5238,9 +5241,7 @@ export interface MutationPromiseChain {
   };
 
   /** Log in user */
-  logIn: (args: {
-    input: AuthenticationInput;
-  }) => LoggedInUserPromiseChain & {
+  logIn: (args: { input: AuthenticationInput }) => LoggedInUserPromiseChain & {
     get: <R extends LoggedInUserRequest>(
       request: R,
       defaultValue?: FieldsSelection<LoggedInUser, R>,
@@ -5256,9 +5257,7 @@ export interface MutationPromiseChain {
   };
 
   /** Update user profile. If setting new password and current password is invalid, BAD_REQUEST is thrown */
-  updateUserProfile: (args: {
-    input: UserProfileInput;
-  }) => UserPromiseChain & {
+  updateUserProfile: (args: { input: UserProfileInput }) => UserPromiseChain & {
     get: <R extends UserRequest>(
       request: R,
       defaultValue?: FieldsSelection<User, R>,
@@ -5295,9 +5294,7 @@ export interface MutationPromiseChain {
 
 export interface MutationObservableChain {
   /** Creates a business Account for the provided business admin */
-  createBrand: (args: {
-    input: CreateBrandInput;
-  }) => BrandObservableChain & {
+  createBrand: (args: { input: CreateBrandInput }) => BrandObservableChain & {
     get: <R extends BrandRequest>(
       request: R,
       defaultValue?: FieldsSelection<Brand, R>,


### PR DESCRIPTION
<!-- All sections are suggestions to encourage good communication between the contributor and the reviewer/s -->

## Description

<!-- Provide a description of the changes made in this PR. -->
### [Creatives table](https://github.com/tekal-ai/memorable-frontend-test/pull/7/commits/83489bbba081aa894967e2abb822d6d25a7e9e3f)
Add everything required to fetch the Creatives filtering by the current Brand.
Add Creatives table.

### [Sectors page](https://github.com/tekal-ai/memorable-frontend-test/pull/7/commits/5404f69d1ff7f816d35c2b467d215f362a3b9a29)
Populate Sectors on logged in User to know the sectors applied to the current Brand.
Create new Sectors route and page.
Create Sectors table.
Create new SectorItem interface.
Create a const that includes all available sectors and export it on from useSectorsDomain.
Add function to know if a Sector is applied to the current Brand.


## 🖼️ Screen Captures

<!-- Relevant screen captures or video to illustrate changes made. Helpful for the reviewers to understand context. -->

https://github.com/tekal-ai/memorable-frontend-test/assets/41996135/dd20b9aa-00a7-4bd4-981f-9227d41095d4


## 🧪 Testing Steps

<!-- Provide reviewers with steps to test changes introduced in the Pull Request. -->

### [Creatives table](https://github.com/tekal-ai/memorable-frontend-test/pull/7/commits/83489bbba081aa894967e2abb822d6d25a7e9e3f)
1. Navigate over to the `/library` page.
2. A table of Creatives should be displayed.
3. Change the Brand selected.
4. The Creatives' table should change the content.
5. If the selected Brand doesn't have Creatives then the `EmptyCreateUI` component must be displayed.

### [Sectors page](https://github.com/tekal-ai/memorable-frontend-test/pull/7/commits/5404f69d1ff7f816d35c2b467d215f362a3b9a29)
1. Navigate over to the `/sectors` page.
2. A table of Sectors should be displayed.
4. Change the Brand selected.
5. The Sectors' table should not change the content.
6. If the selected Brand has Sectors then those Sectors should have a ✅ emoji on the table.


## 📝 Checklist

- [x] PR title is in the format of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) Eg: `feat(scope): my commit message`
- [ ] Relevant README files and documentation have been updated
